### PR TITLE
Add rejectTransaction method

### DIFF
--- a/commands/phantom.js
+++ b/commands/phantom.js
@@ -375,7 +375,7 @@ module.exports = {
     const notificationPage = await playwright.switchToNotification(PROVIDER);
     await playwright.waitAndClick(
       PROVIDER,
-      transactionPageElements.buttons.rejectSign,
+      transactionPageElements.buttons.rejectTransaction,
       notificationPage,
       { waitForEvent: 'close' },
     );
@@ -385,7 +385,7 @@ module.exports = {
     const notificationPage = await playwright.switchToNotification(PROVIDER);
     await playwright.waitAndClick(
       PROVIDER,
-      transactionPageElements.buttons.rejectSign,
+      transactionPageElements.buttons.rejectTransaction,
       notificationPage,
       { waitForEvent: 'close' },
     );

--- a/commands/phantom.js
+++ b/commands/phantom.js
@@ -381,6 +381,16 @@ module.exports = {
     );
     return true;
   },
+  rejectTransaction: async () => {
+    const notificationPage = await playwright.switchToNotification(PROVIDER);
+    await playwright.waitAndClick(
+      PROVIDER,
+      transactionPageElements.buttons.rejectSign,
+      notificationPage,
+      { waitForEvent: 'close' },
+    );
+    return true;
+  },
   confirmIncorrectNetworkStage: async () => {
     const notificationPage = await playwright.switchToNotification(PROVIDER);
     await playwright.waitAndClick(

--- a/pages/phantom/notification-page.js
+++ b/pages/phantom/notification-page.js
@@ -170,8 +170,8 @@ module.exports.signaturePageElements = {
 
 module.exports.transactionPageElements = {
   buttons: {
-    confirmSign: '[data-testid="primary-button"]',
-    rejectSign: '[data-testid="secondary-button"]',
+    confirmTransaction: '[data-testid="primary-button"]',
+    rejectTransaction: '[data-testid="secondary-button"]',
   },
 };
 


### PR DESCRIPTION
## Motivation and context
Was testing transactions on the phantom toolbox and noticed that while we have most of the methods for signatures, we don't have everything for transactions

Clearly and concisely describe the feature added/isses being solved"
Added a rejectTransaction that mimics the MM method. All it does is hit the cancel button.

## Does it fix any issue?
It allows us to add an e2e test for the send transaction method in the toolbox

#(issue)
https://linear.app/phantom-labs/issue/ECO-1974/can-show-and-sign-transaction-dialog


## Other useful info

N/A

## Quality checklist

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough e2e tests.

**⚠️👆 Delete any section you see irrelevant before submitting the pull request 👆⚠️**
