### PR TITLE
chore: updated importing wallet to match shorter onboarding changes

### DIFF
--- a/commands/phantom.js
+++ b/commands/phantom.js
@@ -121,7 +121,7 @@ module.exports = {
     return true;
   },
   importWallet: async (secretWords, password) => {
- await playwright.waitAndClick(
+    await playwright.waitAndClick(
       PROVIDER,
       firstTimeFlowPageElements.importWalletButton,
     );
@@ -164,12 +164,17 @@ module.exports = {
       PROVIDER,
       firstTimeFlowImportPageElements.termsCheckbox,
     );
-    // finish
+    // continue to next screen
     await playwright.waitAndClick(
       PROVIDER,
-      firstTimeFlowImportPageElements.finishAfterPasswordButton,
+      firstTimeFlowImportPageElements.continueAfterPasswordButton,
     );
+    // finish
     await new Promise(resolve => setTimeout(resolve, 1000)); // the transitioning is too fast
+    await playwright.waitAndClick(
+      PROVIDER,
+      firstTimeFlowImportPageElements.getStartedButton,
+    );
     return true;
   },
   closePopupAndTooltips: async () => {

--- a/commands/phantom.js
+++ b/commands/phantom.js
@@ -121,7 +121,7 @@ module.exports = {
     return true;
   },
   importWallet: async (secretWords, password) => {
-    await playwright.waitAndClick(
+ await playwright.waitAndClick(
       PROVIDER,
       firstTimeFlowPageElements.importWalletButton,
     );
@@ -164,23 +164,12 @@ module.exports = {
       PROVIDER,
       firstTimeFlowImportPageElements.termsCheckbox,
     );
-    // continue to next screen
-    await playwright.waitAndClick(
-      PROVIDER,
-      firstTimeFlowImportPageElements.continueAfterPasswordButton,
-    );
-    // shortcut confirmation
-    await new Promise(resolve => setTimeout(resolve, 1000)); // the transitioning is too fast
-    await playwright.waitAndClick(
-      PROVIDER,
-      firstTimeFlowImportPageElements.continueOnShortcutConfirm,
-    );
     // finish
-    await new Promise(resolve => setTimeout(resolve, 1000)); // the transitioning is too fast
     await playwright.waitAndClick(
       PROVIDER,
-      firstTimeFlowImportPageElements.continueOnShortcutConfirm,
+      firstTimeFlowImportPageElements.finishAfterPasswordButton,
     );
+    await new Promise(resolve => setTimeout(resolve, 1000)); // the transitioning is too fast
     return true;
   },
   closePopupAndTooltips: async () => {

--- a/pages/phantom/first-time-flow-page.js
+++ b/pages/phantom/first-time-flow-page.js
@@ -31,9 +31,7 @@ const confirmWordsButton = `[data-testid="onboarding-form-submit-button"]`;
 const passwordInput = `[data-testid="onboarding-form-password-input"]`;
 const confirmPasswordInput = `[data-testid="onboarding-form-confirm-password-input"]`;
 const termsCheckbox = `[data-testid="onboarding-form-terms-of-service-checkbox"]`;
-const continueAfterPasswordButton =
-  '[data-testid="onboarding-form-submit-button"]';
-const continueOnShortcutConfirm =
+const finishAfterPasswordButton =
   '[data-testid="onboarding-form-submit-button"]';
 const importButton = `${newVaultForm} .create-new-vault__submit-button`;
 
@@ -46,8 +44,7 @@ module.exports.firstTimeFlowImportPageElements = {
   termsCheckbox,
   importButton,
   confirmWordsButton,
-  continueAfterPasswordButton,
-  continueOnShortcutConfirm,
+  finishAfterPasswordButton,
 };
 
 const firstTimeFlowCreatePage = '.first-time-flow';

--- a/pages/phantom/first-time-flow-page.js
+++ b/pages/phantom/first-time-flow-page.js
@@ -31,7 +31,9 @@ const confirmWordsButton = `[data-testid="onboarding-form-submit-button"]`;
 const passwordInput = `[data-testid="onboarding-form-password-input"]`;
 const confirmPasswordInput = `[data-testid="onboarding-form-confirm-password-input"]`;
 const termsCheckbox = `[data-testid="onboarding-form-terms-of-service-checkbox"]`;
-const finishAfterPasswordButton =
+const continueAfterPasswordButton =
+  '[data-testid="onboarding-form-submit-button"]';
+const getStartedButton =
   '[data-testid="onboarding-form-submit-button"]';
 const importButton = `${newVaultForm} .create-new-vault__submit-button`;
 
@@ -44,7 +46,8 @@ module.exports.firstTimeFlowImportPageElements = {
   termsCheckbox,
   importButton,
   confirmWordsButton,
-  finishAfterPasswordButton,
+  continueAfterPasswordButton,
+  getStartedButton
 };
 
 const firstTimeFlowCreatePage = '.first-time-flow';


### PR DESCRIPTION
## Motivation and context

There is an extension PR that shortens onboarding by two steps.
These changes correspond to that PR.
Note: we should merge shortly before the other PR is merged to not block others.
https://github.com/phantom/wallet/pull/6070

## Does it fix any issue?

Nope (indirectly: https://linear.app/phantom-labs/issue/IO-2812/remove-socials-and-key-shortcut-from-onboarding)

## Other useful info

N/A

## Quality checklist

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough e2e tests.




