### PR TITLE
fix: add a wait for get started button

### DIFF
--- a/commands/phantom.js
+++ b/commands/phantom.js
@@ -189,6 +189,11 @@ module.exports = {
       firstTimeFlowImportPageElements.continueAfterPasswordButton,
     );
     await new Promise(resolve => setTimeout(resolve, 1000)); // the transitioning is too fast
+    // we need to first wait for the button otherwise it is pressed too fast.
+    await playwright.waitFor(
+      PROVIDER,
+      firstTimeFlowImportPageElements.getStartedButton,
+    );
     // finish
     await playwright.waitAndClick(
       PROVIDER,
@@ -321,7 +326,8 @@ module.exports = {
           .click(mainPageElements.welcome.takeTheTourButtonNext, {
             timeout: 10_000,
           });
-      } catch {}
+      } catch {
+      }
 
       walletAddress = await module.exports.getWalletAddress();
       await playwright.switchToCypressWindow();
@@ -498,7 +504,7 @@ module.exports = {
     if (!Object.keys(mainPageElements.defaultWallet).includes(wallet)) {
       throw new Error(
         'Wallet not supported, support ' +
-          Object.keys(mainPageElements.defaultWallet).join(', '),
+        Object.keys(mainPageElements.defaultWallet).join(', '),
       );
     }
 


### PR DESCRIPTION
## Motivation and context

During onboarding there was an issue where the get started button was pressed very quickly which caused another get started screen to show in the stack instead of concluding the onboarding.

Adding a wait for fixed this issue.

I found that the timeouts are not working properly. It could be that the time is somehow mocked when running playwright tests.
