### PR TITLE
chore: pin external GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,13 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Enable Corepack
         run: corepack enable
 
       - name: Setup Node.js 20.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: 20.x
 
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           version: yarn changeset version


### PR DESCRIPTION
## Summary

- Pin all unpinned external GitHub Action `uses:` references to full 40-character commit SHAs
- Original version tags/branches preserved as inline comments for maintainability
- No other CI changes included

## Motivation

Supply chain security hardening: pinning actions to immutable commit SHAs prevents silent changes from compromised or force-pushed tags.

Part of the org-wide audit tracked in [SEC-6683](https://linear.app/phantom-labs/issue/SEC-6683) and [SEC-7928](https://linear.app/phantom-labs/issue/SEC-7928).

## Test plan

- [ ] CI passes on this branch
- [ ] Verify pinned SHAs match the expected versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)